### PR TITLE
Fixed Build : A problem occurred configuring project ':access_wallpaper'.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace  'sameh.gbibia.access_wallpaper'
     compileSdkVersion 31
 
     compileOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: access_wallpaper
 description: A Flutter plugin that provides a method to access the current system or lock screen wallpaper image as a Uint8List.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/SamehGbuibia/AccessWallpaper-Flutter-Plugin-
 
 environment:


### PR DESCRIPTION
Fixed Build 



Error 

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':access_wallpaper'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: /Users/ttpho/.pub-cache/hosted/pub.dev/access_wallpaper-1.0.0/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```

Flutter Doctor 

```
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.29.0, on macOS 15.3.1 24D70 darwin-arm64, 
[✓] Android toolchain - develop for Android devices (Android SDK version 35.0.1)
[!] Xcode - develop for iOS and macOS (Xcode 16.2)
    ✗ Unable to get list of installed Simulator runtimes.
    ✗ CocoaPods not installed.
        CocoaPods is a package manager for iOS or macOS platform code.
        Without CocoaPods, plugins will not work on iOS or macOS.
        For more info, see https://flutter.dev/to/platform-plugins
      For installation instructions, see
      https://guides.cocoapods.org/using/getting-started.html#installation
[✓] Chrome - develop for the web
[✓] Android Studio (version 2024.2)
[✓] VS Code (version 1.97.2)
[✓] Connected device (5 available)
[✓] Network resources

! Doctor found issues in 1 category.
```